### PR TITLE
Implement prototype subscription assistant backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+.env
+.venv
+.eggs/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
+# AI Abonnemang Agent
 
+Ett prototypprojekt för en AI-assistent som håller koll på återkommande abonnemang. Tjänsten läser in transaktioner och mejl, identifierar återkommande kostnader och ger användaren tydliga val för att förnya eller säga upp abonnemang.
+
+## Funktioner
+- Registrera banktransaktioner och identifiera månatliga prenumerationer.
+- Importera e-postnotiser för att justera förnyelsedatum och flagga prisökningar.
+- Håll koll på aktiva och avslutade abonnemang samt sparade pengar.
+- API-endpoint för dashboard med översikt över kommande förnyelser.
+
+## Kom igång
+1. Installera beroenden:
+   ```bash
+   pip install -e .[development]
+   ```
+2. Starta API-servern:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. Kör tester:
+   ```bash
+   pytest
+   ```
+
+## API-översikt
+- `POST /transactions` – registrerar en transaktion. När ett återkommande mönster hittas returneras abonnemanget.
+- `POST /emails` – importerar ett mejl och klassificerar dess innehåll.
+- `GET /subscriptions` – listar alla kända abonnemang.
+- `POST /subscriptions/{id}/decision` – avsluta eller förnya ett abonnemang.
+- `GET /dashboard` – hämtar sammanfattning av kostnader, sparade pengar och kommande förnyelser.
+
+## Nästa steg
+- Koppla mot riktiga PSD2-/Open Banking-API:er.
+- Lägga till användarhantering och uthållig datalagring (PostgreSQL).
+- Förbättrad NLP för att analysera mejl och aviseringar.
+- Automatiserade uppsägningar via leverantörsspecifika integrationer.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
+
+from . import services
+from .models import (
+    DashboardSummary,
+    DecisionIn,
+    EmailIn,
+    Subscription,
+    TransactionIn,
+)
+
+app = FastAPI(title="AI Subscription Assistant")
+
+
+def get_manager() -> services.SubscriptionManager:  # type: ignore[attr-defined]
+    return services.manager
+
+
+@app.post("/transactions", response_model=Subscription | None)
+def register_transaction(payload: TransactionIn) -> Subscription | None:
+    return get_manager().register_transaction(payload)
+
+
+@app.post("/emails")
+def ingest_email(payload: EmailIn) -> dict:
+    record = get_manager().ingest_email(payload)
+    return record.model_dump()
+
+
+@app.get("/subscriptions", response_model=list[Subscription])
+def list_subscriptions() -> list[Subscription]:
+    return list(get_manager().subscriptions)
+
+
+@app.post("/subscriptions/{subscription_id}/decision", response_model=Subscription)
+def apply_decision(subscription_id: int, payload: DecisionIn) -> Subscription:
+    ids = {sub.id for sub in get_manager().subscriptions}
+    if subscription_id not in ids:
+        raise HTTPException(status_code=404, detail="Subscription not found")
+    return get_manager().apply_decision(subscription_id, payload.decision)
+
+
+@app.get("/dashboard", response_model=DashboardSummary)
+def dashboard() -> DashboardSummary:
+    return get_manager().dashboard()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from datetime import datetime, date
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class SubscriptionStatus(str, Enum):
+    ACTIVE = "active"
+    CANCELLED = "cancelled"
+
+
+class TransactionIn(BaseModel):
+    description: str = Field(..., description="Description as it appears on the bank statement")
+    amount: float = Field(..., description="Transaction amount (negative for debit)")
+    timestamp: datetime = Field(..., description="When the transaction was posted")
+
+
+class EmailIn(BaseModel):
+    subject: str
+    body: str
+    timestamp: datetime
+
+
+class Subscription(BaseModel):
+    id: int
+    provider: str
+    reference: str
+    monthly_cost: float
+    next_renewal_date: date
+    status: SubscriptionStatus = SubscriptionStatus.ACTIVE
+    last_transaction_at: datetime
+    notes: Optional[str] = None
+
+
+class SubscriptionDecision(str, Enum):
+    CANCEL = "cancel"
+    RENEW = "renew"
+
+
+class DecisionIn(BaseModel):
+    decision: SubscriptionDecision
+
+
+class DashboardSummary(BaseModel):
+    active_subscriptions: int
+    cancelled_subscriptions: int
+    monthly_commitment: float
+    total_savings: float
+    upcoming_renewals: list[Subscription]
+
+
+class TransactionRecord(BaseModel):
+    description_key: str
+    description: str
+    amount: float
+    timestamp: datetime
+    subscription_id: Optional[int] = None
+
+
+class EmailRecord(BaseModel):
+    subject: str
+    body: str
+    timestamp: datetime
+    tags: list[str] = Field(default_factory=list)

--- a/app/services.py
+++ b/app/services.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import Dict, Iterable, List, Optional
+
+from .models import (
+    DashboardSummary,
+    EmailIn,
+    EmailRecord,
+    Subscription,
+    SubscriptionDecision,
+    SubscriptionStatus,
+    TransactionIn,
+    TransactionRecord,
+)
+
+
+class SubscriptionManager:
+    """In-memory orchestrator for subscription intelligence."""
+
+    def __init__(self) -> None:
+        self._transactions: List[TransactionRecord] = []
+        self._emails: List[EmailRecord] = []
+        self._subscriptions: Dict[int, Subscription] = {}
+        self._saved_total: float = 0.0
+        self._sequence: int = 0
+
+    # ------------------------------------------------------------------
+    # Public accessors
+    # ------------------------------------------------------------------
+    @property
+    def subscriptions(self) -> Iterable[Subscription]:
+        return self._subscriptions.values()
+
+    @property
+    def saved_total(self) -> float:
+        return round(self._saved_total, 2)
+
+    # ------------------------------------------------------------------
+    # Command handlers
+    # ------------------------------------------------------------------
+    def register_transaction(self, tx: TransactionIn) -> Optional[Subscription]:
+        description_key = self._normalize_description(tx.description)
+        record = TransactionRecord(
+            description_key=description_key,
+            description=tx.description,
+            amount=tx.amount,
+            timestamp=tx.timestamp,
+        )
+        self._transactions.append(record)
+        return self._link_transaction(record)
+
+    def ingest_email(self, email: EmailIn) -> EmailRecord:
+        tags = self._classify_email(email)
+        record = EmailRecord(
+            subject=email.subject,
+            body=email.body,
+            timestamp=email.timestamp,
+            tags=tags,
+        )
+        self._emails.append(record)
+        self._maybe_update_subscription_from_email(record)
+        return record
+
+    def apply_decision(self, subscription_id: int, decision: SubscriptionDecision) -> Subscription:
+        subscription = self._subscriptions[subscription_id]
+        if decision is SubscriptionDecision.CANCEL:
+            if subscription.status is not SubscriptionStatus.CANCELLED:
+                self._saved_total += subscription.monthly_cost
+            subscription = subscription.model_copy(update={
+                "status": SubscriptionStatus.CANCELLED,
+                "notes": "Cancelled via assistant",
+            })
+        else:
+            next_renewal = subscription.next_renewal_date + timedelta(days=30)
+            subscription = subscription.model_copy(update={
+                "status": SubscriptionStatus.ACTIVE,
+                "next_renewal_date": next_renewal,
+                "notes": "Renewed via assistant",
+            })
+        self._subscriptions[subscription_id] = subscription
+        return subscription
+
+    def dashboard(self, horizon_days: int = 14) -> DashboardSummary:
+        active = [s for s in self._subscriptions.values() if s.status is SubscriptionStatus.ACTIVE]
+        cancelled = [s for s in self._subscriptions.values() if s.status is SubscriptionStatus.CANCELLED]
+        upcoming_cutoff = datetime.utcnow().date() + timedelta(days=horizon_days)
+        upcoming = [
+            s for s in active
+            if s.next_renewal_date <= upcoming_cutoff
+        ]
+        monthly_commitment = round(sum(s.monthly_cost for s in active), 2)
+        return DashboardSummary(
+            active_subscriptions=len(active),
+            cancelled_subscriptions=len(cancelled),
+            monthly_commitment=monthly_commitment,
+            total_savings=self.saved_total,
+            upcoming_renewals=sorted(upcoming, key=lambda s: s.next_renewal_date),
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _link_transaction(self, record: TransactionRecord) -> Optional[Subscription]:
+        similar = [tx for tx in self._transactions if tx.description_key == record.description_key]
+        similar.sort(key=lambda tx: tx.timestamp)
+        if len(similar) < 2:
+            return None
+
+        latest, previous = similar[-1], similar[-2]
+        interval = (latest.timestamp - previous.timestamp).days
+        if 27 <= interval <= 33:
+            subscription_id = previous.subscription_id or self._create_subscription_from_transaction(similar)
+            record.subscription_id = subscription_id
+            self._transactions[-1] = record
+            self._update_subscription_from_transactions(subscription_id)
+            return self._subscriptions[subscription_id]
+        return None
+
+    def _create_subscription_from_transaction(self, transactions: List[TransactionRecord]) -> int:
+        latest = transactions[-1]
+        provider = self._derive_provider_name(latest.description)
+        amount = self._average_amount(transactions)
+        next_renewal = (latest.timestamp + timedelta(days=30)).date()
+        self._sequence += 1
+        subscription = Subscription(
+            id=self._sequence,
+            provider=provider,
+            reference=latest.description,
+            monthly_cost=round(abs(amount), 2),
+            next_renewal_date=next_renewal,
+            status=SubscriptionStatus.ACTIVE,
+            last_transaction_at=latest.timestamp,
+        )
+        self._subscriptions[subscription.id] = subscription
+        for tx in transactions:
+            tx.subscription_id = subscription.id
+        return subscription.id
+
+    def _update_subscription_from_transactions(self, subscription_id: int) -> None:
+        subscription_transactions = [
+            tx for tx in self._transactions if tx.subscription_id == subscription_id
+        ]
+        latest = max(subscription_transactions, key=lambda tx: tx.timestamp)
+        avg_amount = self._average_amount(subscription_transactions)
+        next_renewal = (latest.timestamp + timedelta(days=30)).date()
+        subscription = self._subscriptions[subscription_id].model_copy(update={
+            "monthly_cost": round(abs(avg_amount), 2),
+            "next_renewal_date": next_renewal,
+            "last_transaction_at": latest.timestamp,
+        })
+        self._subscriptions[subscription_id] = subscription
+
+    def _maybe_update_subscription_from_email(self, email: EmailRecord) -> None:
+        if "price_increase" in email.tags:
+            for subscription in self._subscriptions.values():
+                note = f"Price increase detected on {email.timestamp.date()}"
+                self._subscriptions[subscription.id] = subscription.model_copy(update={"notes": note})
+        if "renewal_notice" in email.tags:
+            grouped: Dict[str, List[Subscription]] = defaultdict(list)
+            for subscription in self._subscriptions.values():
+                grouped[subscription.provider.lower()].append(subscription)
+            provider = self._derive_provider_name(email.subject)
+            matches = grouped.get(provider.lower())
+            if matches:
+                for subscription in matches:
+                    next_date = (email.timestamp + timedelta(days=7)).date()
+                    self._subscriptions[subscription.id] = subscription.model_copy(update={
+                        "next_renewal_date": next_date,
+                        "notes": "Renewal reminder synced from email",
+                    })
+
+    @staticmethod
+    def _derive_provider_name(reference: str) -> str:
+        cleaned = "".join(ch if ch.isalpha() or ch.isspace() else " " for ch in reference)
+        tokens = [token for token in cleaned.split() if token]
+        return tokens[0].capitalize() if tokens else reference.strip().title()
+
+    @staticmethod
+    def _average_amount(records: List[TransactionRecord]) -> float:
+        return sum(record.amount for record in records) / len(records)
+
+    @staticmethod
+    def _normalize_description(description: str) -> str:
+        return "".join(ch.lower() for ch in description if ch.isalnum())
+
+    @staticmethod
+    def _classify_email(email: EmailIn) -> List[str]:
+        text = f"{email.subject} {email.body}".lower()
+        tags: List[str] = []
+        if any(keyword in text for keyword in ["renew", "förnya", "fornyelse", "renewal"]):
+            tags.append("renewal_notice")
+        if any(keyword in text for keyword in ["price increase", "höjs", "higher rate"]):
+            tags.append("price_increase")
+        return tags
+
+
+manager = SubscriptionManager()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ai-abonnemang-agent"
+version = "0.1.0"
+description = "Prototype backend for an AI subscription management assistant"
+authors = [{name = "AI Assistant"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "fastapi",
+    "uvicorn",
+    "pydantic>=1.10",
+]
+
+[project.optional-dependencies]
+development = [
+    "pytest",
+    "httpx",
+]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+pythonpath = ["."]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import services
+from app.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_manager_state():
+    services.manager = services.SubscriptionManager()
+    yield
+    services.manager = services.SubscriptionManager()
+
+
+def test_subscription_detected_from_transactions():
+    now = datetime.utcnow()
+    payload = {
+        "description": "Spotify ABO",
+        "amount": -99.0,
+        "timestamp": now.isoformat(),
+    }
+    response = client.post("/transactions", json=payload)
+    assert response.status_code == 200
+    assert response.json() is None
+
+    second_payload = {
+        "description": "Spotify ABO",
+        "amount": -99.0,
+        "timestamp": (now + timedelta(days=30)).isoformat(),
+    }
+    response = client.post("/transactions", json=second_payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["provider"] == "Spotify"
+    assert data["monthly_cost"] == 99.0
+
+
+def test_cancel_subscription_updates_savings():
+    now = datetime.utcnow()
+    client.post(
+        "/transactions",
+        json={
+            "description": "Netflix subscription",
+            "amount": -129.0,
+            "timestamp": (now - timedelta(days=60)).isoformat(),
+        },
+    )
+    client.post(
+        "/transactions",
+        json={
+            "description": "Netflix subscription",
+            "amount": -129.0,
+            "timestamp": (now - timedelta(days=30)).isoformat(),
+        },
+    )
+
+    subscriptions = client.get("/subscriptions").json()
+    assert subscriptions
+    subscription_id = subscriptions[-1]["id"]
+
+    response = client.post(
+        f"/subscriptions/{subscription_id}/decision",
+        json={"decision": "cancel"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancelled"
+
+    dashboard = client.get("/dashboard").json()
+    assert dashboard["total_savings"] >= 129.0
+
+
+def test_dashboard_upcoming_renewals_from_email_signal():
+    now = datetime.utcnow()
+    client.post(
+        "/transactions",
+        json={
+            "description": "Disney+ order",
+            "amount": -59.0,
+            "timestamp": (now - timedelta(days=60)).isoformat(),
+        },
+    )
+    client.post(
+        "/transactions",
+        json={
+            "description": "Disney+ order",
+            "amount": -59.0,
+            "timestamp": (now - timedelta(days=30)).isoformat(),
+        },
+    )
+
+    email_response = client.post(
+        "/emails",
+        json={
+            "subject": "Disney+ renewal reminder",
+            "body": "Your subscription will renew soon",
+            "timestamp": now.isoformat(),
+        },
+    )
+    assert email_response.status_code == 200
+
+    dashboard = client.get("/dashboard").json()
+    assert dashboard["upcoming_renewals"]
+    renewal = dashboard["upcoming_renewals"][0]
+    assert renewal["notes"] == "Renewal reminder synced from email"


### PR DESCRIPTION
## Summary
- scaffold a FastAPI application that exposes endpoints for transactions, emails, subscription decisions, and dashboard insights
- add domain models and an in-memory subscription manager that links recurring transactions, ingests email signals, and tracks savings
- document setup steps and provide pytest coverage for subscription detection, cancellation savings, and renewal reminders

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cd6efdc0988325b8d6892b9aa325ac